### PR TITLE
Add SoloLuck (sololuck.io) to pool quick-link detection

### DIFF
--- a/src/web/axe-os/src/app/components/home/home.component.ts
+++ b/src/web/axe-os/src/app/components/home/home.component.ts
@@ -161,7 +161,10 @@ export class HomeComponent implements OnInit {
         } else if (poolUrl.includes('dgb-stratum.solominer.net')) {
           const address = poolUser.split('.')[0]
           return `https://digibyte.solominer.net/#/app/${address}`;
-        } 
+        } else if (poolUrl.includes('sololuck.io')) {
+          const address = poolUser.split('.')[0]
+          return `https://sololuck.io/users/${address}`;
+        }
         else {
           return undefined;
         }


### PR DESCRIPTION
### What
Adds a quick-link branch so that when a miner is pointed at a `sololuck.io` stratum host, the AxeOS Home page renders a working "View on pool" link to the per-miner stats page: `https://sololuck.io/users/<address>`.

This mirrors the same entry already **merged upstream** in bitaxeorg/ESP-Miner (#1785) and already present in the shufps/ESP-Miner-NerdQAxePlus fork, adapted to this repo's inline `quickLink$` if/else chain in `src/web/axe-os/src/app/components/home/home.component.ts`.

### Why
SoloLuck is a true per-miner solo pool (ckpool `-B`, non-custodial — your BTC address is your stratum username). It runs a low-difficulty tier on port 3333 aimed at Bitaxe/NerdMiner/NMAxe-class hardware, with a Jakarta stratum node for low latency to Southeast-Asian miners. Today a miner pointed there gets no clickable pool link on the Home page; this adds the same small convenience already shipped for public-pool.io, ocean.xyz, ckpool, molepool, solominer, etc.

Full disclosure: I run SoloLuck. This PR only adds the link entry, in the established pattern — no other behaviour changes.

### Change
A single `else if` branch, consistent with the surrounding entries, added to the `quickLink$` chain right before the final `else { return undefined; }`:

```ts
} else if (poolUrl.includes('sololuck.io')) {
  const address = poolUser.split('.')[0]
  return `https://sololuck.io/users/${address}`;
}
```

### Testing
- Pure string-matching addition; no new deps, no network calls, no change to any existing pool branch.
- `poolUser.split('.')[0]` extracts the BTC address from an `address.worker` username, same as every neighbouring branch (bech32 addresses contain no dots).
- Link target is live: `https://sololuck.io/users/<address>` returns the per-miner stats page (HTTP 200).

Happy to adjust the match string or formatting to your preference.
